### PR TITLE
chore(conf): Fix publication of build result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ bower_components
 
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
-dist
 
 # Dependency directories
 node_modules/


### PR DESCRIPTION
- Remove "dist" folder from `.gitignore` file in order to publish it with other published resources.