### PR TITLE
chore(ci): fix NPM publish phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ branches:
 env:
   - CAN_PUBLISH=$(sh ./.can-publish.sh)
 script:
+  - npm run snyk-protect
   - npm run lint
   - npm run test:ci
   - npm run build

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "test:ci": "npm run test && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "test:watch": "jest --watch",
     "release": "git add dist && standard-version --commit-all --message=\"chore(release): %s [ci skip]\" && git push https://${GITHUB_TOKEN}@github.com/tverhoken/stryker-diff-runner.git --follow-tags $(git rev-parse --abbrev-ref HEAD):master",
-    "snyk-protect": "snyk protect",
-    "prepare": "npm run snyk-protect"
+    "snyk-protect": "snyk protect"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Remove `prepare` script that was executed just before NPM publish and was in error.
- Run `snyk-protec` script at the beginning of the pipeline instead of juste before publishing to NPM.